### PR TITLE
Updated base image to nvidia/cuda:11.0.3-devel-ubuntu18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # base image maintained by the NVIDIA CUDA Installer Team - https://hub.docker.com/r/nvidia/cuda/
-FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04
+FROM nvidia/cuda:11.4.3-devel-ubuntu18.04
 
 # install os packages
 RUN apt-get update \


### PR DESCRIPTION
The old base image was removed from dockerhub so the Dockerfile couldn't build.

See https://gitlab.com/nvidia/container-images/cuda/-/issues/209 for the list of removed docker tags when they end of life their images. 

https://gitlab.com/nvidia/container-images/cuda/-/blob/master/doc/container_tags.pdf

11.0.3 will be EOL Jan-2024

11.4.3 is currently Active so will be supported for longer, so that might be a better option than 11.0.3 which was the smallest increment that was still available.

On testing it looks like this brings in 2.0.0 of lightning.pytorch which will require some additional changes to get working.

import lightning.pytorch as pl instead of import pytorch_lightning as pl.

NotImplementedError: Support for `training_epoch_end` has been removed in v2.0.0.